### PR TITLE
sci-biology/fsl now installs to /usr/lib/fsl and sets up user environment

### DIFF
--- a/sci-biology/fsl/files/99fsl
+++ b/sci-biology/fsl/files/99fsl
@@ -1,0 +1,3 @@
+FSLDIR=/usr/lib/fsl
+PATH=${FSLDIR}/bin
+

--- a/sci-biology/fsl/files/fsl.sh
+++ b/sci-biology/fsl/files/fsl.sh
@@ -1,0 +1,2 @@
+source ${FSLDIR}/etc/fslconf/fsl.sh
+


### PR DESCRIPTION
> Thanks for the pull request. And many thanks for your involvement - I would very much appreciate any other patches - as I said, especially on the FSL build which at present installs only one README file (out of the 1.3 GB of the source) o.0.

You might wanna take a look at
https://devmanual.gentoo.org/ebuild-writing/functions/src_install/index.html
on how to handle packages in src_install() that do not provide "make install". BTW: You will see the reason in the default src_install for why the README file was installed.

Basically, this is no common "configure && make && make install" thingie. That's why the package manager does not know how to install the built files. But, if you know how to install it manually, you could mimic that procedure inside the ebuild. You could, on the other hand, disregard the provided "build" script, and build and install each subpackage on its own -- but for the moment I doubt that this would be easier.

As far as I can see from the documentation at
https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/SourceCode#Using_the_compiled_binaries
https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/ShellSetup
the idea is to copy the files yourself to a central location and set up the environment for all users accordingly. There is no script for that.

Apart from that it seems like a dependency to GLU is missing.

And regarding src_unpack() take a look here:
http://devmanual.gentoo.org/ebuild-writing/functions/src_unpack/
You will see, that the default implementation is sufficient for your needs.

Anyways, I made this pull request for FSL. Your part in src_compile() seems to work fine. I added src_install() which now installs most of the FSL files to "/usr/lib/fsl". Don't know if I overlooked something, but I am pretty sure there are some files (e.g. C/C++ source files) in /usr/lib/fsl/extras which don't belong in a final installation.

The required shell environment for FSL should be working if "/etc/profile" is sourced. I put some files into "/etc/env.d" and "/etc/profile.d". Most shells should pick up on that in Gentoo. At least on my system a user has now easy access to the programs in "/usr/lib/fsl/bin".

I'd like the ebuild to depend on virtual/glu for GLU, but this downgrades media-libs/mesa on my system, so I choose media-libs/glu instead.

The ebuild seems to work, but there are still two errors in the build.log, which are ignored by the build script provided by FSL. Don't know if they concern you.

!!ERROR in INSTALL!!
  Could not fully install the following projects successfully:
    tk

!!ERROR in BUILD!!
  Could not make the following projects successfully:  
   extras 

There is still a lot of room for improvement
1) FSL uses a version of tcl which is provided with the package. It is described here
https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/SourceCode
how to circumvent the provided tcl library and use the system's libraries instead. I think it's part of Gentoo's philosophy to not install libraries more than once if possible.
2) The documentation is installed at the moment at /usr/lib/fsl/doc, but it would be better situated at /usr/share/doc/fsl
3) The statements creating symbolic links for build system configurations with gcc 4.6/4.7 on 64-bit machines should be in src_prepare(). So should be the addpredict statement, too. Basically, everything that is not compiling/linking (or any similar build process) should be there. It's part of EAPI 2.

Have fun.
